### PR TITLE
Fix WAN_IP

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/svc-rtorrent/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/svc-rtorrent/run
@@ -6,5 +6,5 @@ if [ -z "${WAN_IP}" ]; then
     exec s6-setuidgid rtorrent rtorrent -o import=/etc/rtorrent/.rtlocal.rc
 else
     echo "Running rtorrent with enforced WAN IP ${WAN_IP}"
-    exec s6-setuidgid rtorrent rtorrent -o import=/etc/rtorrent/.rtlocal.rc -i ${WAN_IP}
+    exec s6-setuidgid rtorrent rtorrent -o import=/etc/rtorrent/.rtlocal.rc -o network.local_address.set=${WAN_IP}
 fi


### PR DESCRIPTION
Fixes `Failed to parse command line option: Command "ip" does not exist` after rtorrent upgrade